### PR TITLE
Prevent header image dragging.

### DIFF
--- a/src/drag-upload.js
+++ b/src/drag-upload.js
@@ -71,7 +71,11 @@ document.body.addEventListener('drop', (ev) => {
 
     packSavefile.push([id, text]);
   };
-  reader.readAsText(file);
+  try {
+    reader.readAsText(file);
+  } catch (error) {
+    setDragging(false);
+  }
 
   document.body.classList.remove('is-dropping-file');
   setDragging(false);

--- a/src/style.css
+++ b/src/style.css
@@ -339,6 +339,7 @@ img.header {
   width: calc((1278 / 175) * 50px);
   margin: auto;
   margin-top: 20px;
+  /* pointer-events: none; */
 }
 body.dark img.header {
   filter: invert(1);

--- a/src/style.css
+++ b/src/style.css
@@ -339,7 +339,7 @@ img.header {
   width: calc((1278 / 175) * 50px);
   margin: auto;
   margin-top: 20px;
-  /* pointer-events: none; */
+  pointer-events: none;
 }
 body.dark img.header {
   filter: invert(1);


### PR DESCRIPTION
Hi~~

Senpaiiii, when uu cwick and dwag da Elemental Lite header image, da game thinks it's an ewement pack that's supposed to be dwopped. This makes you unabwe to do anything ewse on da page, and da onwy way to fix it is to wewoad da page. XDDD!

![image](https://user-images.githubusercontent.com/40444294/93405902-4e25c800-f85c-11ea-8b0b-c485eef3d380.png)

I added `pointer-events: none;` under `img.header` in the CSS to pwevent cwicking and dwagging. Tested on Chrome and Firefox.

Can u pwease merge my pwull wequest senpai?!! UwU